### PR TITLE
Couple of style changes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -339,6 +339,7 @@ footer a:hover {
 .tt-course-code {
   display: block;
   text-align: center;
+  font-size: 0.9em;
 }
 
 
@@ -386,12 +387,12 @@ input {
   color: black !important;
 }
 
-#insertSlotBtn {
-  margin: 1em;
+#insertSlotBtn .btn {
+  white-space: normal;
 }
 
-#insertSlotBtn .btn {
-  white-space: normal!important;
+#insertSlotBtn:empty {
+  margin-bottom: 0;
 }
 
 #inputCourseCode,

--- a/index.html
+++ b/index.html
@@ -350,8 +350,7 @@
               </div>
             </div>
             <!-- inserted slot buttons here -->
-            <div id="insertSlotBtn" class="row">
-            </div>
+            <div id="insertSlotBtn" class="form-group col-xs-12"></div>
             <div class="form-group col-xs-12 col-md-6">
               <label for="inputSlotString" class="control-label">Slot:</label>
               <div>

--- a/js/autocomplete_course.js
+++ b/js/autocomplete_course.js
@@ -10,9 +10,7 @@ function addSlotSelectionButtons(type, slot, faculty, credits, venue) {
     btnValue = slot + '|' + faculty + '|' + type + '|' + venue + '|' + credits;
 
     var insert =
-        '<div class="col-xs-12 col-sm-6 col-md-4">' +
-        '<button class="btn btn-default btn-block" type="button" value="' + btnValue + '" onclick="slotSelectionBtnClicked(this.value)">' + btnText + '</button>' +
-        '</div>';
+        '<a class="btn btn-default" href="#" data-value="' + btnValue + '" onclick="event.preventDefault();slotSelectionBtnClicked(this.getAttribute(\'data-value\'));">' + btnText + '</a>';
 
     return insert;
 }
@@ -28,15 +26,30 @@ function slotSelectionBtnClicked(value) {
 }
 
 function getSlots(searchCode) {
+    var BUTTONS_PER_ROW = 3;
+    var total = 0;
+    var btnGrpHtml = '';
+    var insert = '';
+
     $('#insertSlotBtn').html('');
-    var insert = '<div class="btn-group" role="group">';
     $.each(all_data, function (key, value) {
         if (value.CODE == searchCode) {
             // append slots to add course panel
-            insert = insert + addSlotSelectionButtons(value.TYPE, value.SLOT, value.FACULTY, value.CREDITS.toString(), value.VENUE);
+            if(total % BUTTONS_PER_ROW === 0) {
+                btnGrpHtml += btnGrpHtml ? '</div>' : '';
+                insert += btnGrpHtml;
+                btnGrpHtml = '';
+                btnGrpHtml += '<div class="btn-group btn-group-justified" role="group">';
+            }
+
+            btnGrpHtml += addSlotSelectionButtons(value.TYPE, value.SLOT, value.FACULTY, value.CREDITS.toString(), value.VENUE);
+            ++total;
         }
     });
-    insert = insert + '</div>'
+
+    btnGrpHtml += '</div>';
+    insert += btnGrpHtml;
+
     $('#insertSlotBtn').append(insert);
 }
 
@@ -69,9 +82,7 @@ var courseCodeOption = {
         }
     },
 
-    placeholder: "eg: ITE1008",
-
-    theme: "round"
+    placeholder: "eg: ITE1008"
 };
 
 var courseTitleOption = {
@@ -98,10 +109,9 @@ var courseTitleOption = {
         }
     },
 
-    placeholder: "eg: Open Source programming",
-
-    theme: "round"
+    placeholder: "eg: Open Source programming"
 };
 
 $("#inputCourseTitle").easyAutocomplete(courseTitleOption);
 $("#inputCourseCode").easyAutocomplete(courseCodeOption);
+$("div.easy-autocomplete").attr("style", "");

--- a/js/colorChange.js
+++ b/js/colorChange.js
@@ -123,7 +123,7 @@ var CRM = (function () {
 			var $slot = $("." + slot);
 
 			if (!~$slot.text().indexOf(code)) {
-				$slot.append('<span class="tt-course-code">' + code + '<br>' + venue + '</span>');
+				$slot.append('<span class="tt-course-code">' + code + ' - ' + venue + '</span>');
 			}
 		},
 


### PR DESCRIPTION
+ Better layout of course suggestions in a proper 3 button justified `.btn-group`. Looks cleaner without the extra white spaces. :+1: 
+ Removed the easyac theme to match the bootstrap default.
+ Removes the fixed-width styles set by easyac to make the inputs responsive.
+ Courses added to Time Table are `0.9em` and an hyphen divides the course code and venue.