### PR TITLE
(Possibly Buggy) Operations account for J component

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,6 +253,9 @@
                 </div>
               </div>
 
+              <!-- To prevent clashes when J component is added. -->
+              <input type="hidden" id="inputIsProject" value="false">
+
               <div class="form-group col-xs-12">
                 <div class="text-right">
                   <button type="button" id="clearCourseBtn" class="btn btn-default">Clear</button>

--- a/js/autocomplete_course.js
+++ b/js/autocomplete_course.js
@@ -64,7 +64,7 @@ function initAutocomplete(allData, uniqueData) {
         var title = $(this).data('title');
         var slot = $(this).data('slot');
         var faculty = $(this).data('faculty');
-        // var type = $(this).data('type');
+        var type = $(this).data('type');
         var venue = $(this).data('venue');
         var credits = $(this).data('credits');
 
@@ -74,6 +74,7 @@ function initAutocomplete(allData, uniqueData) {
         $('#inputFaculty').val(faculty);
         $('#inputVenue').val(venue);
         $('#inputCourseCredits').val(credits);
+        $('#inputIsProject').val(type === 'EPJ' ? 'true' : 'false');
     });
 
     $("#insertCourseSelectionOptions").on("dblclick", "button", function () {
@@ -107,7 +108,7 @@ function getSlotSelectionButton(code, title, type, slot, faculty, credits, venue
     $slotButton.data('title', title);
     $slotButton.data('slot', slot);
     $slotButton.data('faculty', faculty);
-    // $slotButton.data('type', type);
+    $slotButton.data('type', type);
     $slotButton.data('venue', venue);
     $slotButton.data('credits', credits);
 


### PR DESCRIPTION
Addresses #63. The following are the behaviors added with this update:
1. J component won't clash with its counterpart when added.
1. J component is hidden in the time table when it's added along with its counterpart.
1. Two J components added for the same slot will clash.
1. Hopefully won't break the existing time tables. (**Not fully tested**
1. Different faculties can be taken for J component and the counterpart and no clash would appear. **Note: ** This is not confirmed to be the rule that registration will follow.
1. Fixed a bug in course removal which used `substr`. This won't allow proper removal of courses with IDs >= 10.