### PR TITLE
Fixed load back to panel bug

### DIFF
--- a/src/js/autocomplete_course.js
+++ b/src/js/autocomplete_course.js
@@ -183,7 +183,7 @@ function getSlotSelectionButton(
     return $slotButton;
 }
 
-function addSlotButtons(code) {
+export function addSlotButtons(code) {
     var BUTTONS_PER_DIV = 4;
 
     var buttonsPerDiv = BUTTONS_PER_DIV;

--- a/src/js/color_change.js
+++ b/src/js/color_change.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import localforage from 'localforage';
 
-import { resetFilterSlotArr } from './autocomplete_course';
+import { resetFilterSlotArr, addSlotButtons } from './autocomplete_course';
 
 let timeTableStorage = [
     {
@@ -144,7 +144,10 @@ $(function() {
 
         var courseSplit = course.split('-');
         var courseCode = courseSplit[0].trim();
-        var courseTitle = courseSplit.slice(1).join('-').trim();
+        var courseTitle = courseSplit
+            .slice(1)
+            .join('-')
+            .trim();
 
         // [0: courseId, 1: courseCode, 2:courseTitle, 3: faculty, 4: slotArray, 5: venue, 6: credits, 7: isProject]
         activeTable.data.push([
@@ -201,11 +204,8 @@ $(function() {
             .eq(5)
             .text();
 
-        $('#inputCourseCode')
-            .val(courseCode)
-            .trigger('change');
-        $('#inputCourseTitle')
-            .val(courseTitle)
+        $('#inputCourse')
+            .val(courseCode + ' - ' + courseTitle)
             .trigger('change');
         $('#inputFaculty')
             .val(faculty)
@@ -220,10 +220,7 @@ $(function() {
             .val(credits)
             .trigger('change');
 
-        try {
-            // Function may not work if autocomplete is not loaded
-            addSlotButtons(courseCode);
-        } catch (error) {}
+        addSlotButtons(courseCode);
 
         $(this)
             .find('.close')


### PR DESCRIPTION
This bug was partly caused by one of my PRs (#174). When a course is double clicked in the course list, it doesn't load back to the panel. I noticed something else that caused this bug.

```js
try {
    // Function may not work if autocomplete is not loaded
    addSlotButtons(courseCode);
} catch (error) {}
```

This function was in a `try...catch` block and so I'm guessing that's why no one noticed it was swallowing it's error every time. The `addSlotButtons()` function was never imported in this file, and so this function was never properly called. The comment says it won't work if autocomplete isn't loaded, but the function loads data from the `.json` file and has nothing to do with autocomplete, so I removed the `try...catch` block.