### PR TITLE
Added a last-update field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "FFCSonTheGo",
     "version": "1.0.0",
+    "last-update": "Fall Semester 2021-22",
     "main": "index.js",
     "repository": "https://github.com/vatz88/FFCSonTheGo.git",
     "author": "Vatsal Joshi <vatz88@gmail.com>",

--- a/src/index.html
+++ b/src/index.html
@@ -259,8 +259,8 @@
                     </div>
 
                     <div class="modal-footer justify-content-start">
-                        <b>Last updated for:</b>
-                        <span id="version">Fall Semester 2021-22</span>
+                        <b>Last update:</b>
+                        <span id="last-update">Unknown</span>
                     </div>
                 </div>
             </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -9,9 +9,14 @@ import html2canvas from 'html2canvas';
 import './color_change';
 import { removeTouchHoverCSSRule } from './utils';
 
+const lastUpdate = require('../../package.json')['last-update'];
+
 $(function() {
     // disable hover for touch screen devices
     removeTouchHoverCSSRule();
+
+    // Setting the last updated semester
+    $('#last-update').text(lastUpdate);
 
     $('.quick-selection .btn').click(function() {
         $(this).blur();


### PR DESCRIPTION
This PR adds a `last-update` field in the package to hold the last updated semester. This way, the semester can be updated only once in `package.json` and it'll reflect everywhere. As of now, it is only present in the index page, but it can be added in the `README.md` as well.